### PR TITLE
인증 토큰 오류 수정

### DIFF
--- a/apps/server/src/middlewares/auth.middleware.ts
+++ b/apps/server/src/middlewares/auth.middleware.ts
@@ -1,6 +1,6 @@
 import jwt from 'jsonwebtoken';
 import { Request, Response, NextFunction } from 'express';
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+const JWT_SECRET = process.env.JWT_ACCESS_SECRET || 'your-secret-key';
 
 export function authenticateToken(req: Request, res: Response, next: NextFunction): void {
   const authHeader = req.headers['authorization'];
@@ -15,7 +15,8 @@ export function authenticateToken(req: Request, res: Response, next: NextFunctio
       res.sendStatus(403);
       return;
     }
-    (req as any).user = user;
+
+    res.locals.user = user;
     next();
   });
 }

--- a/apps/server/src/services/auth.service.ts
+++ b/apps/server/src/services/auth.service.ts
@@ -1,5 +1,6 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { User } from '@prisma/client';
 
 const SALT_ROUNDS = 10;
 const JWT_ACCESS_SECRET = process.env.JWT_ACCESS_SECRET || '';
@@ -18,13 +19,13 @@ export async function comparePassword(plain: string, hashed: string) {
 }
 
 /** 액세스 토큰 발급 */
-export function generateAccessToken(userId: number, role: string) {
-  return jwt.sign({ userId, role }, JWT_ACCESS_SECRET, { expiresIn: JWT_ACCESS_EXPIRES_IN });
+export function generateAccessToken(user: Omit<User, 'pw'>) {
+  return jwt.sign(user, JWT_ACCESS_SECRET, { expiresIn: JWT_ACCESS_EXPIRES_IN });
 }
 
 /** 리프레시 토큰 발급 */
-export function generateRefreshToken(user: { id: string }) {
-  return jwt.sign({ id: user.id }, JWT_REFRESH_SECRET, { expiresIn: JWT_REFRESH_EXPIRES_IN });
+export function generateRefreshToken(user: Omit<User, 'pw'>) {
+  return jwt.sign(user, JWT_REFRESH_SECRET, { expiresIn: JWT_REFRESH_EXPIRES_IN });
 }
 
 /** 리프레시 토큰 검증 */


### PR DESCRIPTION
## 인증 토큰 오류 수정

### 주요 원인

- **ENV 설정 불일치**: JWT 토큰 발급 시 사용되는 시크릿 키(`JWT_SECRET`)의 환경 변수명이 실제 서버에서 사용하는 값과 일치하지 않아 서명 검증에 실패함.
- **토큰 페이로드 불일치**: 토큰 생성 시 `userId`와 `id` 간 key 명칭이 일치하지 않아, 검증 및 파싱 과정에서 오류 발생.

### 변경 사항

- **ENV 키 통일**: 환경 변수명과 코드 내 JWT 시크릿 키 사용을 일치시켜 검증 오류 해결.
- **페이로드 구성 정비**: 토큰에 포함되는 `User` 정보에서 `pw`를 제외한 모든 속성이 포함되도록 구성 변경.

###  개선 사항

- **미들웨어 내 사용자 정보 전달 방식 변경**:  
  기존:  
  ```ts
  (req as any).user = user;
  ```
  변경 후:  
  ```ts
  res.locals.user = user;
  ```  
  → 타입 안정성과 Express의 표준 컨벤션에 맞춰 `res.locals`를 통해 사용자 정보를 다음 미들웨어로 전달.

###  추가 참고 사항

- **불필요한 속성 제거 시 타입 안전성 확보**:  
  다음과 같이 구조 분해 할당 시 `pw`는 제거하고 나머지만 유지.  
  ```ts
  const { pw: _, ...rest } = user;
  ```  
  → 사용하지 않는 필드는 `_`로 표기하여 의도적으로 제외함을 명시.
