### PR TITLE
output 제거 및 User → Users 모델명 변경

### DIFF
--- a/apps/server/prisma/schema.prisma
+++ b/apps/server/prisma/schema.prisma
@@ -6,7 +6,6 @@
 
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {
@@ -14,14 +13,14 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-model User {
+model Users {
   no         Int      @id @default(autoincrement()) // 기본 키: 숫자, 자동 증가
   id         String   @unique                      // 사용자 아이디 (중복 불가)
   pw         String                               // 비밀번호
   name       String                               // 이름
   role       Role                                 // 역할 (ADMIN 또는 SUB)
   createdAt  DateTime @default(now())             // 생성일시 (자동 생성)
-  refreshToken String?  // 리프레시 토큰 저장용 필드 (nullable)
+  refreshToken String? @map("refresh-token")  // 리프레시 토큰 저장용 필드 (nullable)
 }
 
 enum Role {

--- a/apps/server/prisma/seed.ts
+++ b/apps/server/prisma/seed.ts
@@ -10,7 +10,7 @@ async function main() {
   const hashedPassword = await bcrypt.hash(pw, 10);
 
   // 기본 관리자 유저 생성
-  await prisma.user.upsert({
+  await prisma.users.upsert({
     where: { id },
     update: {
       pw: hashedPassword,

--- a/apps/server/src/controllers/auth.controller.ts
+++ b/apps/server/src/controllers/auth.controller.ts
@@ -6,13 +6,13 @@ import {
   generateRefreshToken,
   verifyRefreshToken,
 } from '@/services/auth.service';
-import { User } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 /** 로그인 */
 export async function login(req: Request, res: Response) {
   const { id, pw } = req.body;
 
-  const user = await prisma.user.findUnique({ where: { id } });
+  const user = await prisma.users.findUnique({ where: { id } });
 
   if (!user) {
     res.status(401).json({ message: 'Invalid credentials' });
@@ -47,7 +47,7 @@ export async function me(_: Request, res: Response) {
   try {
     const { id } = res.locals.user;
 
-    const user = await prisma.user.findUnique({
+    const user = await prisma.users.findUnique({
       where: { id },
       select: { id: true, name: true, role: true }, // 비밀번호 등 제외
     });
@@ -77,7 +77,7 @@ export async function refresh(req: Request, res: Response) {
     const payload = verifyRefreshToken(refreshToken);
     const { iat, exp, ...user } = payload;
 
-    const newAccessToken = generateAccessToken(user as Omit<User, 'pw'>);
+    const newAccessToken = generateAccessToken(user as Omit<Users, 'pw'>);
     res.status(200).json({ accessToken: newAccessToken });
     return;
   } catch (err) {

--- a/apps/server/src/services/auth.service.ts
+++ b/apps/server/src/services/auth.service.ts
@@ -1,6 +1,6 @@
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
-import { User } from '@prisma/client';
+import { Users } from '@prisma/client';
 
 const SALT_ROUNDS = 10;
 const JWT_ACCESS_SECRET = process.env.JWT_ACCESS_SECRET || '';
@@ -19,12 +19,12 @@ export async function comparePassword(plain: string, hashed: string) {
 }
 
 /** 액세스 토큰 발급 */
-export function generateAccessToken(user: Omit<User, 'pw'>) {
+export function generateAccessToken(user: Omit<Users, 'pw'>) {
   return jwt.sign(user, JWT_ACCESS_SECRET, { expiresIn: JWT_ACCESS_EXPIRES_IN });
 }
 
 /** 리프레시 토큰 발급 */
-export function generateRefreshToken(user: Omit<User, 'pw'>) {
+export function generateRefreshToken(user: Omit<Users, 'pw'>) {
   return jwt.sign(user, JWT_REFRESH_SECRET, { expiresIn: JWT_REFRESH_EXPIRES_IN });
 }
 

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -21,5 +21,5 @@
   },
 
   "include": ["src"], // 빌드 및 타입체크할 소스
-  "exclude": ["node_modules", "dist"] // 제외할 경로
+  "exclude": ["node_modules", "dist", "generated", "prisma"] // 제외할 경로
 }


### PR DESCRIPTION
- `prisma` 설정에서 불필요한 `output` 옵션 제거  
- 모델명을 `User` → `Users`로 변경하여 실제 DB 테이블(`users`)과의 네이밍 일관성 확보  
- 타입 불일치 및 클라이언트 생성 경로 오류 해결