### PR TITLE
[Web] 비회원 주문서 입력 폼 기능 개선 #121

### DIFF
--- a/apps/web/src/components/guest-privacy-agreement.tsx
+++ b/apps/web/src/components/guest-privacy-agreement.tsx
@@ -101,7 +101,7 @@ function GuestPrivacyAgreement({ onAgreed, agreed, setAgreed }: AgreedProps) {
         </Card>
       </AlertDialogTrigger>
 
-      <AlertDialogContent>
+      <AlertDialogContent className="h-[600px] max-h-[80vh] overflow-y-auto">
         <AlertDialogCancel className="relative top-1 -right-11/12 cursor-pointer w-10">
           <X />
         </AlertDialogCancel>

--- a/apps/web/src/components/non-customer-order-form.tsx
+++ b/apps/web/src/components/non-customer-order-form.tsx
@@ -2,9 +2,7 @@
  * 비회원 주문서 폼
  */
 
-import useToast from '@/hooks/useToast';
-import type { BankCodeProps, BreadProps, DeliveryProps } from '@/interface/bread-interface';
-import { insertOrders, searchBankList, searchDeliveryList } from '@/services/apis';
+import type { BankCodeProps, DeliveryProps } from '@/interface/bread-interface';
 import type { FormSchema } from '@/validate/form-schema';
 import {
   Button,
@@ -25,84 +23,37 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@appabbang/ui';
-import { useQuery } from '@tanstack/react-query';
-import type { SubmitHandler, UseFormReturn } from 'react-hook-form';
+import type { UseFormReturn } from 'react-hook-form';
 import DaumPostApi from './daum-post-api';
 import GuestPrivacyAgreement from './guest-privacy-agreement';
 import { useState } from 'react';
 
 interface NonCustomerOrderFormProp {
   form: UseFormReturn<FormSchema>;
-  paymentList: BreadProps[];
-  totalPrice: number;
+  onSelectedDeliveryTp: (delivery: string) => void;
+  bank: {
+    bankLoading: boolean;
+    bankData: BankCodeProps[] | undefined;
+  };
+  delivery: {
+    deliveryLoading: boolean;
+    deliveryData: DeliveryProps[] | undefined;
+  };
+  handleOrderSubmit: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
 /** Main Function */
-function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrderFormProp) {
-  const { addToast } = useToast();
+function NonCustomerOrderForm({
+  form,
+  onSelectedDeliveryTp,
+  bank,
+  delivery,
+  handleOrderSubmit,
+}: NonCustomerOrderFormProp) {
   const [deliveryMethodNo, setDeliveryMethodNo] = useState<string>('');
   const [same, setSame] = useState<boolean>(false);
-
-  /** 배송방법 목록 API */
-  const { isLoading: deliveryLoading, data: deliveryData } = useQuery({
-    queryKey: ['deliveryList'],
-    queryFn: searchDeliveryList,
-  });
-
-  /** 은행 목록 API */
-  const { isLoading: bankLoading, data: bankData } = useQuery({
-    queryKey: ['bankList'],
-    queryFn: searchBankList,
-  });
-
-  /** 유효성 검증 수행하기 전, 빵 결제목록 확인 */
-  const handleOrderSubmit = (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-
-    if (paymentList.length === 0) {
-      addToast({
-        message: '빵 결제목록이 1개 이상 선택돼야 주문이 가능합니다.',
-        type: 'error',
-      });
-
-      return;
-    }
-
-    form.handleSubmit(onSubmit)(e);
-  };
-
-  /**
-   * 유효성 검증 끝난 후 비회원 주문 건 저장
-   * 조건 1. 주문 건이 1건 이상 존재해야 함.
-   * 조건 2. 개인정보 수집 이용 동의가 되어야 함.
-   */
-  const onSubmit: SubmitHandler<FormSchema> = (data) => {
-    const orderItems = Array();
-
-    try {
-      if (!data.agreed) throw new Error('비회원인 경우, 개인정보 수집 및 이용 동의가 필요합니다.');
-      if (paymentList.length === 0)
-        throw new Error('결제목록이 1건 이상 존재해야 주문이 가능합니다.');
-
-      /** orderItems 생성 */
-      paymentList.map((bread, _) => {
-        orderItems.push({
-          breadNo: bread.no,
-          quantity: bread.count,
-        });
-      });
-
-      data.orderItems = orderItems;
-      data.totalPrice = totalPrice;
-
-      insertOrders(data); // 비회원 주문서 저장
-    } catch (e: any) {
-      addToast({
-        message: e.message,
-        type: 'error',
-      });
-    }
-  };
+  const { bankLoading, bankData } = bank;
+  const { deliveryLoading, deliveryData } = delivery;
 
   /** 주소 API로 받아온 결과값을 상태값과 form value값에 대입한다. */
   const setFormAddress = (newAddrList: string[]) => {
@@ -346,7 +297,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                         <SelectContent>
                           <SelectGroup>
                             <SelectLabel>은행</SelectLabel>
-                            {bankData?.data.map((bank: BankCodeProps, idx: number) => {
+                            {bankData?.map((bank: BankCodeProps, idx: number) => {
                               return (
                                 <SelectItem
                                   key={idx}
@@ -436,13 +387,15 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                           field.onChange(value);
 
                           // 현재 select에 선택된 option value와 동일한 데이터의 deliveryType 값을 저장한다.
-                          const { deliveryType } = deliveryData?.data.find(
+                          const found = deliveryData?.find(
                             ({ no }: DeliveryProps) => no.toString() === value,
                           );
+                          // 배송방법이 없으면 기본값 설정(공백)
+                          const deliveryType = found?.deliveryType ?? '';
 
                           setDeliveryMethodNo(deliveryType);
-                          // 배송타입이 10이 아니면 배송메세지는 공백처리
-                          deliveryType !== '10' && form.setValue('message', '');
+                          onSelectedDeliveryTp(deliveryType);
+                          deliveryType !== '10' && form.setValue('message', ''); // 배송타입이 10이 아니면 배송메세지는 공백처리
                         }}
                       >
                         <SelectTrigger id="deliveryMethodNo" className="w-[150px]">
@@ -451,7 +404,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                         <SelectContent>
                           <SelectGroup>
                             <SelectLabel>배송방법</SelectLabel>
-                            {deliveryData?.data.map((delivery: DeliveryProps, idx: number) => {
+                            {deliveryData?.map((delivery: DeliveryProps, idx: number) => {
                               return (
                                 <SelectItem
                                   key={idx}

--- a/apps/web/src/components/non-customer-order-form.tsx
+++ b/apps/web/src/components/non-customer-order-form.tsx
@@ -5,6 +5,15 @@
 import type { BankCodeProps, DeliveryProps } from '@/interface/bread-interface';
 import type { FormSchema } from '@/validate/form-schema';
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
   Button,
   Checkbox,
   Form,
@@ -27,9 +36,11 @@ import type { UseFormReturn } from 'react-hook-form';
 import DaumPostApi from './daum-post-api';
 import GuestPrivacyAgreement from './guest-privacy-agreement';
 import { useState } from 'react';
+import { useRef } from 'react';
 
 interface NonCustomerOrderFormProp {
   form: UseFormReturn<FormSchema>;
+  totalPrice: number;
   onSelectedDeliveryTp: (delivery: string) => void;
   bank: {
     bankLoading: boolean;
@@ -45,6 +56,7 @@ interface NonCustomerOrderFormProp {
 /** Main Function */
 function NonCustomerOrderForm({
   form,
+  totalPrice,
   onSelectedDeliveryTp,
   bank,
   delivery,
@@ -54,6 +66,7 @@ function NonCustomerOrderForm({
   const [same, setSame] = useState<boolean>(false);
   const { bankLoading, bankData } = bank;
   const { deliveryLoading, deliveryData } = delivery;
+  const formRef = useRef<HTMLFormElement>(null);
 
   /** 주소 API로 받아온 결과값을 상태값과 form value값에 대입한다. */
   const setFormAddress = (newAddrList: string[]) => {
@@ -66,10 +79,12 @@ function NonCustomerOrderForm({
   /** 비회원 개인정보처리방침 동의 flag 처리 */
   const onAgreed = (flag: boolean) => form.setValue('agreed', flag); // onSubmit에서 사용하기 위해 정의함.
 
+  // const
+
   return (
     <div className="flex justify-center w-full">
       <Form {...form}>
-        <form onSubmit={handleOrderSubmit} className="w-2/3">
+        <form ref={formRef} onSubmit={handleOrderSubmit} className="w-2/3">
           <div className="flex items-start mt-5 mb-5 pl-10 pr-10">
             <FormField
               control={form.control}
@@ -501,10 +516,26 @@ function NonCustomerOrderForm({
             setAgreed={(flag: boolean) => form.setValue('agreed', flag)}
           />
 
-          <div className="m-10">
-            <Button type="submit" className="text-2xl h-15 w-full">
-              주문하기
-            </Button>
+          <div className="m-10 text-2xl flex justify-end">
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button variant="outline">주문하기</Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>현재 주문을 완료하시겠습니까?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    총 금액은 {totalPrice.toLocaleString()}원 입니다.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>취소</AlertDialogCancel>
+                  <AlertDialogAction type="submit" onClick={() => formRef.current?.requestSubmit()}>
+                    완료
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
           </div>
         </form>
       </Form>

--- a/apps/web/src/components/non-customer-order-form.tsx
+++ b/apps/web/src/components/non-customer-order-form.tsx
@@ -16,6 +16,7 @@ import {
   FormLabel,
   FormMessage,
   Input,
+  Label,
   Select,
   SelectContent,
   SelectGroup,
@@ -28,6 +29,7 @@ import { useQuery } from '@tanstack/react-query';
 import type { SubmitHandler, UseFormReturn } from 'react-hook-form';
 import DaumPostApi from './daum-post-api';
 import GuestPrivacyAgreement from './guest-privacy-agreement';
+import { useState } from 'react';
 
 interface NonCustomerOrderFormProp {
   form: UseFormReturn<FormSchema>;
@@ -35,8 +37,11 @@ interface NonCustomerOrderFormProp {
   totalPrice: number;
 }
 
+/** Main Function */
 function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrderFormProp) {
   const { addToast } = useToast();
+  const [deliveryMethodNo, setDeliveryMethodNo] = useState<string>('');
+  const [same, setSame] = useState<boolean>(false);
 
   /** 배송방법 목록 API */
   const { isLoading: deliveryLoading, data: deliveryData } = useQuery({
@@ -130,10 +135,14 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                       placeholder="주문자 이름 입력"
                       {...field}
                       {...form.register('name')}
-                      onChange={(e) => {
-                        form.setValue('recipientName', e.target.value);
-                        field.onChange(e);
-                      }}
+                      // onChange={(e) => {
+                      //   form.setValue('recipientName', e.target.value, {
+                      //     shouldDirty: true,
+                      //     shouldTouch: true,
+                      //     shouldValidate: true,
+                      //   });
+                      //   field.onChange(e);
+                      // }}
                     />
                   </FormControl>
                   <FormMessage />
@@ -155,10 +164,14 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                       id="mobileNumber"
                       {...field}
                       {...form.register('mobileNumber')}
-                      onChange={(e) => {
-                        form.setValue('recipientMobile', e.target.value);
-                        field.onChange(e);
-                      }}
+                      // onChange={(e) => {
+                      //   form.setValue('recipientMobile', e.target.value, {
+                      //     shouldDirty: true,
+                      //     shouldTouch: true,
+                      //     shouldValidate: true,
+                      //   });
+                      //   field.onChange(e);
+                      // }}
                       placeholder="주문자 전화번호 입력"
                     />
                   </FormControl>
@@ -166,6 +179,25 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                 </FormItem>
               )}
             />
+          </div>
+
+          <div className="flex items-center gap-3 pl-10 pr-10">
+            <Checkbox
+              id="same"
+              onCheckedChange={(flag) => {
+                // 주문자와 수령인이 동일하면 true
+                if (flag) {
+                  setSame(true);
+                  form.setValue('recipientName', form.getValues('name')); // 수령인
+                  form.setValue('recipientMobile', form.getValues('mobileNumber')); // 수령인 전화번호
+                } else {
+                  setSame(false);
+                  form.setValue('recipientName', ''); // 수령인
+                  form.setValue('recipientMobile', ''); // 수령인 전화번호
+                }
+              }}
+            />
+            <Label htmlFor="same">주문자와 수령인 정보가 동일합니다.</Label>
           </div>
 
           <div className="flex items-start mt-5 mb-5 pl-10 pr-10">
@@ -182,6 +214,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                       type="text"
                       id="recipientName"
                       placeholder="수령인 입력"
+                      disabled={same ? true : false}
                       {...field}
                       {...form.register('recipientName')}
                     />
@@ -203,6 +236,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                     <Input
                       type="text"
                       id="recipientMobile"
+                      disabled={same ? true : false}
                       {...field}
                       {...form.register('recipientMobile')}
                       placeholder="수령인 전화번호 입력"
@@ -396,7 +430,21 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                         </SelectTrigger>
                       </Select>
                     ) : (
-                      <Select value={field.value} onValueChange={field.onChange}>
+                      <Select
+                        value={field.value}
+                        onValueChange={(value) => {
+                          field.onChange(value);
+
+                          // 현재 select에 선택된 option value와 동일한 데이터의 deliveryType 값을 저장한다.
+                          const { deliveryType } = deliveryData?.data.find(
+                            ({ no }: DeliveryProps) => no.toString() === value,
+                          );
+
+                          setDeliveryMethodNo(deliveryType);
+                          // 배송타입이 10이 아니면 배송메세지는 공백처리
+                          deliveryType !== '10' && form.setValue('message', '');
+                        }}
+                      >
                         <SelectTrigger id="deliveryMethodNo" className="w-[150px]">
                           <SelectValue placeholder="배송방법 선택" />
                         </SelectTrigger>
@@ -438,6 +486,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                       type="text"
                       id="message"
                       placeholder="배송 메세지 입력"
+                      disabled={deliveryMethodNo !== '10'}
                       {...field}
                       {...form.register('message')}
                     />
@@ -461,7 +510,7 @@ function NonCustomerOrderForm({ form, paymentList, totalPrice }: NonCustomerOrde
                     type="text"
                     id="orderPw"
                     className="w-full"
-                    placeholder="송장번호 입력"
+                    placeholder="주문 비밀번호 입력"
                     {...field}
                     {...form.register('orderPw')}
                   />

--- a/apps/web/src/components/non-customer-order-form.tsx
+++ b/apps/web/src/components/non-customer-order-form.tsx
@@ -5,15 +5,6 @@
 import type { BankCodeProps, DeliveryProps } from '@/interface/bread-interface';
 import type { FormSchema } from '@/validate/form-schema';
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
   Button,
   Checkbox,
   Form,
@@ -32,15 +23,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@appabbang/ui';
-import type { UseFormReturn } from 'react-hook-form';
+import { Controller, type UseFormReturn } from 'react-hook-form';
 import DaumPostApi from './daum-post-api';
 import GuestPrivacyAgreement from './guest-privacy-agreement';
 import { useState } from 'react';
-import { useRef } from 'react';
 
 interface NonCustomerOrderFormProp {
   form: UseFormReturn<FormSchema>;
-  totalPrice: number;
   onSelectedDeliveryTp: (delivery: string) => void;
   bank: {
     bankLoading: boolean;
@@ -56,7 +45,6 @@ interface NonCustomerOrderFormProp {
 /** Main Function */
 function NonCustomerOrderForm({
   form,
-  totalPrice,
   onSelectedDeliveryTp,
   bank,
   delivery,
@@ -66,25 +54,33 @@ function NonCustomerOrderForm({
   const [same, setSame] = useState<boolean>(false);
   const { bankLoading, bankData } = bank;
   const { deliveryLoading, deliveryData } = delivery;
-  const formRef = useRef<HTMLFormElement>(null);
+  const [checked, setChecked] = useState<boolean>(false); // 주문자-수령인 동일인물 체크여부
+  const [disabledAddrDtl, setDisabledAddrDtl] = useState<boolean>(true);
 
   /** 주소 API로 받아온 결과값을 상태값과 form value값에 대입한다. */
   const setFormAddress = (newAddrList: string[]) => {
     const [zipcode, address, addressDetail] = newAddrList;
     zipcode && form.setValue('zipcode', zipcode); // 우편번호
-    address && form.setValue('address', address); // 주소
-    addressDetail && form.setValue('addressDetail', addressDetail); // 상세주소
+
+    if (address && addressDetail) {
+      form.setValue('address', `${address}(${addressDetail})`); // 주소(상세주소)
+      setDisabledAddrDtl(false);
+    }
   };
 
   /** 비회원 개인정보처리방침 동의 flag 처리 */
   const onAgreed = (flag: boolean) => form.setValue('agreed', flag); // onSubmit에서 사용하기 위해 정의함.
 
-  // const
+  /** 주문자-수령인 정보가 동일하지 않을 때 */
+  const checkedRecipient = (_: React.ChangeEvent<HTMLInputElement>) => {
+    checked && setSame(false);
+    form.setValue('same', false);
+  };
 
   return (
     <div className="flex justify-center w-full">
       <Form {...form}>
-        <form ref={formRef} onSubmit={handleOrderSubmit} className="w-2/3">
+        <form onSubmit={handleOrderSubmit} className="w-2/3">
           <div className="flex items-start mt-5 mb-5 pl-10 pr-10">
             <FormField
               control={form.control}
@@ -100,15 +96,10 @@ function NonCustomerOrderForm({
                       id="name"
                       placeholder="주문자 이름 입력"
                       {...field}
-                      {...form.register('name')}
-                      // onChange={(e) => {
-                      //   form.setValue('recipientName', e.target.value, {
-                      //     shouldDirty: true,
-                      //     shouldTouch: true,
-                      //     shouldValidate: true,
-                      //   });
-                      //   field.onChange(e);
-                      // }}
+                      onChange={(e) => {
+                        field.onChange(e);
+                        checkedRecipient(e);
+                      }}
                     />
                   </FormControl>
                   <FormMessage />
@@ -130,14 +121,6 @@ function NonCustomerOrderForm({
                       id="mobileNumber"
                       {...field}
                       {...form.register('mobileNumber')}
-                      // onChange={(e) => {
-                      //   form.setValue('recipientMobile', e.target.value, {
-                      //     shouldDirty: true,
-                      //     shouldTouch: true,
-                      //     shouldValidate: true,
-                      //   });
-                      //   field.onChange(e);
-                      // }}
                       placeholder="주문자 전화번호 입력"
                     />
                   </FormControl>
@@ -148,22 +131,39 @@ function NonCustomerOrderForm({
           </div>
 
           <div className="flex items-center gap-3 pl-10 pr-10">
-            <Checkbox
-              id="same"
-              onCheckedChange={(flag) => {
-                // 주문자와 수령인이 동일하면 true
-                if (flag) {
-                  setSame(true);
-                  form.setValue('recipientName', form.getValues('name')); // 수령인
-                  form.setValue('recipientMobile', form.getValues('mobileNumber')); // 수령인 전화번호
-                } else {
-                  setSame(false);
-                  form.setValue('recipientName', ''); // 수령인
-                  form.setValue('recipientMobile', ''); // 수령인 전화번호
-                }
-              }}
-            />
-            <Label htmlFor="same">주문자와 수령인 정보가 동일합니다.</Label>
+            <FormField
+              control={form.control}
+              name="same"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Checkbox
+                      id="same"
+                      checked={field.value}
+                      onCheckedChange={(flag) => {
+                        // 주문자와 수령인이 동일하면 true
+                        if (flag) {
+                          setSame(true);
+                          setChecked(true);
+                          form.setValue('recipientName', form.getValues('name')); // 수령인
+                          form.setValue('recipientMobile', form.getValues('mobileNumber')); // 수령인 전화번호
+                        } else {
+                          setSame(false);
+                          setChecked(false);
+                          form.setValue('recipientName', ''); // 수령인
+                          form.setValue('recipientMobile', ''); // 수령인 전화번호
+                        }
+
+                        field.onChange(flag);
+                      }}
+                    />
+                  </FormControl>
+                  <FormLabel htmlFor="same" errorCheck={false}>
+                    <span className="text-red-700">*</span> 주문자와 수령인 정보가 동일합니다.
+                  </FormLabel>
+                </FormItem>
+              )}
+            ></FormField>
           </div>
 
           <div className="flex items-start mt-5 mb-5 pl-10 pr-10">
@@ -254,6 +254,7 @@ function NonCustomerOrderForm({
                       id="addressDetail"
                       className="w-full"
                       placeholder="배송지 상세주소 입력"
+                      disabled={disabledAddrDtl}
                       {...field}
                       {...form.register('addressDetail')}
                     />
@@ -516,26 +517,10 @@ function NonCustomerOrderForm({
             setAgreed={(flag: boolean) => form.setValue('agreed', flag)}
           />
 
-          <div className="m-10 text-2xl flex justify-end">
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button variant="outline">주문하기</Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>현재 주문을 완료하시겠습니까?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    총 금액은 {totalPrice.toLocaleString()}원 입니다.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>취소</AlertDialogCancel>
-                  <AlertDialogAction type="submit" onClick={() => formRef.current?.requestSubmit()}>
-                    완료
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
+          <div className="m-10">
+            <Button type="submit" className="text-2xl h-15 w-full">
+              주문하기
+            </Button>
           </div>
         </form>
       </Form>

--- a/apps/web/src/routes/order/form.tsx
+++ b/apps/web/src/routes/order/form.tsx
@@ -151,6 +151,7 @@ function RouteComponent() {
     bankCode: '', // 은행코드
     accountNumber: '', // 계좌번호
     accountHolderName: '', // 예금주
+    same: false, // 주문자-수령인 동일여부
   };
 
   /** form과 schema 연결 */
@@ -338,7 +339,6 @@ function RouteComponent() {
             {/* 비회원 정보 입력 form */}
             <NonCustomerOrderForm
               form={form}
-              totalPrice={totalPrice}
               onSelectedDeliveryTp={onSelectedDeliveryTp}
               bank={{ bankLoading, bankData: bankData?.data }}
               delivery={{ deliveryLoading, deliveryData: deliveryData?.data }}

--- a/apps/web/src/routes/order/form.tsx
+++ b/apps/web/src/routes/order/form.tsx
@@ -338,6 +338,7 @@ function RouteComponent() {
             {/* 비회원 정보 입력 form */}
             <NonCustomerOrderForm
               form={form}
+              totalPrice={totalPrice}
               onSelectedDeliveryTp={onSelectedDeliveryTp}
               bank={{ bankLoading, bankData: bankData?.data }}
               delivery={{ deliveryLoading, deliveryData: deliveryData?.data }}

--- a/apps/web/src/routes/order/form.tsx
+++ b/apps/web/src/routes/order/form.tsx
@@ -13,12 +13,13 @@ import OrderFormSkeleton from '@/components/order-form-skeleton';
 import BreadSearch from '@/components/bread-search';
 import CardComment from '@/components/card-comment';
 import Payment from '@/components/Payment';
-import { useForm } from 'react-hook-form';
+import { useForm, type SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { formSchema } from '@/validate/form-schema';
 import NonCustomerOrderForm from '@/components/non-customer-order-form';
-import { searchBreadList } from '@/services/apis';
+import { insertOrders, searchBankList, searchBreadList, searchDeliveryList } from '@/services/apis';
 import type { FormSchema } from '@/validate/form-schema';
+import useToast from '@/hooks/useToast';
 
 /**********************************************************************************/
 /** Route */
@@ -33,6 +34,7 @@ function RouteComponent() {
   const [paymentList, setPaymentList] = useState<BreadProps[]>([]); // 결제목록
   const [errMsg, setErrMsg] = useState<string>(''); // 에러메세지
   const [keyword, setKeyword] = useState<string>(''); // 빵 키워드
+  const [fee, setFee] = useState<number>(0); // 배송비
   const [totalCount, setTotalCount] = useState<number>(0); // 최종 수량
   const [totalPrice, setTotalPrice] = useState<number>(0); // 최종 금액
 
@@ -120,6 +122,10 @@ function RouteComponent() {
     [onCountChange, onRemove],
   );
 
+  /** 우체국 한정으로 배송비 3,000원 추가 */
+  const onSelectedDeliveryTp = (value: string) => {
+    value === '10' ? setFee(3000) : setFee(0);
+  };
   /**********************************************************************************/
   /**
    * 유효성 검사 로직
@@ -154,9 +160,73 @@ function RouteComponent() {
   });
 
   /**********************************************************************************/
+  /** APIs */
+  /** 배송방법 목록 API */
+  const { isLoading: deliveryLoading, data: deliveryData } = useQuery({
+    queryKey: ['deliveryList'],
+    queryFn: searchDeliveryList,
+  });
+
+  /** 은행 목록 API */
+  const { isLoading: bankLoading, data: bankData } = useQuery({
+    queryKey: ['bankList'],
+    queryFn: searchBankList,
+  });
+
+  /** form onSubmit 핸들러 */
+  const handleOrderSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (paymentList.length === 0) {
+      addToast({
+        message: '빵 결제목록이 1개 이상 선택돼야 주문이 가능합니다.',
+        type: 'error',
+      });
+
+      return;
+    }
+
+    form.handleSubmit(onSubmit)(e);
+  };
+
+  /**
+   * 유효성 검증 끝난 후 비회원 주문 건 저장
+   * 조건 1. 주문 건이 1건 이상 존재해야 함.
+   * 조건 2. 개인정보 수집 이용 동의가 되어야 함.
+   */
+  const onSubmit: SubmitHandler<FormSchema> = (data) => {
+    const orderItems = Array();
+
+    try {
+      if (!data.agreed) throw new Error('비회원인 경우, 개인정보 수집 및 이용 동의가 필요합니다.');
+      if (paymentList.length === 0)
+        throw new Error('결제목록이 1건 이상 존재해야 주문이 가능합니다.');
+
+      /** orderItems 생성 */
+      paymentList.map((bread, _) => {
+        orderItems.push({
+          breadNo: bread.no,
+          quantity: bread.count,
+        });
+      });
+
+      data.orderItems = orderItems;
+      data.totalPrice = totalPrice;
+
+      insertOrders(data); // 비회원 주문서 저장
+    } catch (e: any) {
+      addToast({
+        message: e.message,
+        type: 'error',
+      });
+    }
+  };
+  /**********************************************************************************/
   /**
    * React Hooks
    */
+  const { addToast } = useToast();
+
   /** 빵 목록 조회 API */
   const { isLoading, data, error } = useQuery({
     queryKey: ['allBreadList'],
@@ -182,7 +252,7 @@ function RouteComponent() {
     );
 
     setTotalCount(count);
-    setTotalPrice(price);
+    setTotalPrice(price + fee); // 빵 목록 금액의 합 + 배송비
 
     form.setValue(
       'orderItems',
@@ -191,7 +261,7 @@ function RouteComponent() {
         quantity: bread.count,
       })),
     );
-  }, [paymentList]);
+  }, [paymentList, fee]);
 
   return isLoading ? (
     <OrderFormSkeleton />
@@ -237,9 +307,23 @@ function RouteComponent() {
               : paymentList.map((data, i) => <Payment key={i} bread={data} handlers={handlers} />)}
           </div>
 
+          <div className="mt-5 mb-5 mr-10 text-right font-bold text-[18px]">
+            <ul className="flex justify-end text-red-700">
+              <li className="w-1/3"></li>
+              <li className="w-1/3">배송비 :</li>
+              <li className="w-xs">{fee.toLocaleString()}원</li>
+            </ul>
+          </div>
+
           <div className="mt-5 mb-5 mr-10 text-right font-bold">
             <CardTitle>
-              총 금액 : {totalPrice.toLocaleString()}원 ({totalCount}개)
+              <ul className="flex justify-end">
+                <li className="w-1/3"></li>
+                <li className="w-1/3">총 금액({totalCount}개) :</li>
+                <li className="w-xs">
+                  <CardTitle>{totalPrice.toLocaleString()}원</CardTitle>
+                </li>
+              </ul>
             </CardTitle>
           </div>
 
@@ -252,7 +336,13 @@ function RouteComponent() {
             </CardContent>
 
             {/* 비회원 정보 입력 form */}
-            <NonCustomerOrderForm form={form} paymentList={paymentList} totalPrice={totalPrice} />
+            <NonCustomerOrderForm
+              form={form}
+              onSelectedDeliveryTp={onSelectedDeliveryTp}
+              bank={{ bankLoading, bankData: bankData?.data }}
+              delivery={{ deliveryLoading, deliveryData: deliveryData?.data }}
+              handleOrderSubmit={handleOrderSubmit}
+            />
           </div>
         </Card>
       </div>

--- a/apps/web/src/validate/form-schema.ts
+++ b/apps/web/src/validate/form-schema.ts
@@ -69,8 +69,10 @@ export const formSchema = z.object({
   accountHolderName: z // 예금주
     .string({ required_error: '예금주명을 입력 바랍니다.' })
     .min(minNum, { message: `예금주명은 ${minMsg}` })
-    .max(5, { message: `예금주명은 ${maxMsg}` })
-    .regex(/^[가-힣+$]/, { message: `예금주명은 ${regExpMsg}` }),
+    .max(20, { message: `예금주명은 최대 20자까지 입력할 수 있습니다.` })
+    .regex(/^[가-힣A-Z_(),]{1,20}$/, {
+      message: `예금주명은 영문+한글+특수문자 사용이 가능합니다. (특수문자: (, ), _`,
+    }),
 });
 
 export type FormSchema = z.infer<typeof formSchema>;

--- a/apps/web/src/validate/form-schema.ts
+++ b/apps/web/src/validate/form-schema.ts
@@ -73,6 +73,8 @@ export const formSchema = z.object({
     .regex(/^[가-힣A-Z_(),]{1,20}$/, {
       message: `예금주명은 영문+한글+특수문자 사용이 가능합니다. (특수문자: (, ), _`,
     }),
+  same: z // 주문자-수령인 동일여부
+    .boolean(),
 });
 
 export type FormSchema = z.infer<typeof formSchema>;


### PR DESCRIPTION
💼 작업 설명
비회원 주문서 입력 폼 기능 개선

✅ 주문자, 수령인 정보가 동일한 경우 체크박스를 체크하게하고, 체크박스 값이 true이면 수령인 Input disabled 처리
✅ 주문 비밀번호 placeholder 수정
✅ 개인정보 수집 및 이용 동의서 모달 패딩값 필요, 백그라운드 딤 처리, 닫기 버튼 고정
✅ 예금주 특수문자 허용 (, ), A-Z, _, 가-힣
✅ 틀린 값을 입력한 뒤 submit 버튼 클릭 시 오류가 발생하고 다시 정상으로 입력하면 '주문자' 오류메세지는 사라지고 '수령인' 오류메세지는 그대로 남는 이슈 확인
✅ 배송방법 - deliveryType === '10'이 아닌 option 선택 시 배송 메세지 disabled 처리
✅ 배송방법 select 값 변경 시 배송메세지 초기화
✅ 배송비 추가 :: 배송방법 - fee 이용 (deliveryType === '10' 한정)
✅ api 호출 위치 변경 :: 상위 컴포넌트에서 하위 컴포넌트로 prop 전달하는 방식으로 변경하기
✅ 주문 전 확인메세지 alert confirm 기능 추가