### PR TITLE
[Server] 주문차수 등록/수정 개선사항 #163

### DIFF
--- a/apps/server/src/controllers/order-round.controller.ts
+++ b/apps/server/src/controllers/order-round.controller.ts
@@ -33,11 +33,6 @@ export async function create(req: Request, res: Response) {
   const image = req.files?.image as UploadedFile[] | UploadedFile | undefined;
   let orderRound;
 
-  // 주문차수로 등록하기 전, 현재 등록하려는 빵의 상태가 판매중(10), 출시예정(50)인지 검토하기
-  const findResult = await OrderRoundService.findBreadStatus(breadNoList);
-  if ('code' in findResult) return res.status(500).json(findResult);
-  else null;
-
   !image
     ? (orderRound = await OrderRoundService.createWithoutImage(model)) // 이미지 없는 주문차수 등록
     : (orderRound = await OrderRoundService.createWithImage(model, image)); // 이미지 있는 주문차수 등록
@@ -70,11 +65,6 @@ export async function update(req: Request, res: Response) {
       seq,
       name,
     });
-
-  // 주문차수로 등록하기 전, 현재 등록하려는 빵의 상태가 판매중(10), 출시예정(50)인지 검토하기
-  const findResult = await OrderRoundService.findBreadStatus(breadNoList);
-  if ('code' in findResult) return res.status(500).json(findResult);
-  else null;
 
   // 이미지 유무에 따른 주문차수 수정
   !image

--- a/apps/server/src/controllers/order-round.controller.ts
+++ b/apps/server/src/controllers/order-round.controller.ts
@@ -26,12 +26,17 @@ export async function getOne(req: Request, res: Response) {
  */
 export async function create(req: Request, res: Response) {
   const { no, seq, name, breadNoList: breadNoListStr, startedAt, endedAt } = req.body;
-  const breadNoListJson = JSON.parse(breadNoListStr); // json parsing
+  let breadNoListJson = JSON.parse(breadNoListStr); // json parsing
   // breadNoList에서 breadNo 값만 추출
   const breadNoList = breadNoListJson.map((bread: { breadNo: number }) => bread.breadNo);
   const model = { no, seq, name, breadNoList, startedAt, endedAt };
   const image = req.files?.image as UploadedFile[] | UploadedFile | undefined;
   let orderRound;
+
+  // 주문차수로 등록하기 전, 현재 등록하려는 빵의 상태가 판매중(10), 출시예정(50)인지 검토하기
+  const findResult = await OrderRoundService.findBreadStatus(breadNoList);
+  if ('code' in findResult) return res.status(500).json(findResult);
+  else null;
 
   !image
     ? (orderRound = await OrderRoundService.createWithoutImage(model)) // 이미지 없는 주문차수 등록
@@ -50,7 +55,7 @@ export async function create(req: Request, res: Response) {
  */
 export async function update(req: Request, res: Response) {
   const { no, seq, name, public_id, breadNoList: breadNoListStr, startedAt, endedAt } = req.body;
-  const breadNoListJson = JSON.parse(breadNoListStr); // json parsing
+  let breadNoListJson = JSON.parse(breadNoListStr); // json parsing
   // breadNoList에서 breadNo 값만 추출
   const breadNoList = breadNoListJson.map((bread: { breadNo: number }) => bread.breadNo);
   const model = { no: Number(no), seq, name, public_id, breadNoList, startedAt, endedAt };
@@ -65,6 +70,11 @@ export async function update(req: Request, res: Response) {
       seq,
       name,
     });
+
+  // 주문차수로 등록하기 전, 현재 등록하려는 빵의 상태가 판매중(10), 출시예정(50)인지 검토하기
+  const findResult = await OrderRoundService.findBreadStatus(breadNoList);
+  if ('code' in findResult) return res.status(500).json(findResult);
+  else null;
 
   // 이미지 유무에 따른 주문차수 수정
   !image

--- a/apps/server/src/services/bread.service.ts
+++ b/apps/server/src/services/bread.service.ts
@@ -82,7 +82,7 @@ export const getAllForCustomer = async () => {
 
     return data;
   });
-  console.log(result);
+
   return result;
 };
 

--- a/apps/server/src/services/bread.service.ts
+++ b/apps/server/src/services/bread.service.ts
@@ -8,6 +8,7 @@ import { ClientType } from '@/types/client-payload';
 
 const IMAGE_TARGET_TYPE = '10'; // 빵 이미지 코드
 const CUSTOMER_AVALIABLE_BREAD_STATUS = ['10', '40', '50']; // 고객은 판매, 재료소진, 출시예정 만 조회 가능
+const USER_AVALIABLE_BREAD_STATUS = ['10', '50']; // 관리자는 판매, 출시예정만 조회한다. (주문차수 전용)
 
 /** 빵 목록 전체 조회 */
 export const getAll = async () => {
@@ -343,4 +344,30 @@ export const remove = async (noList: number[]) => {
       where: { publicId: { in: publicIdList } },
     });
   });
+};
+
+/** 빵 상세 조회 - 관리자 전용
+ * 주문차수에 등록할 빵 목록을 조회한다.
+ * 단, 빵 상태가 판매중(10), 출시예정(50)인 빵만 등록할 수 있다.
+ */
+export const getBread = async (type: ClientType | undefined, no: number) => {
+  const result = await prisma.$transaction(async (tx) => {
+    const bread = await tx.bread.findUnique({
+      where: { no },
+    });
+
+    if (!bread) throw AppError.notFound('빵을 찾을 수 없습니다.', { breadNo: no });
+
+    // 관리자는 판매, 출시예정 만 조회 가능
+    if (type !== ClientType.USER && !USER_AVALIABLE_BREAD_STATUS.includes(bread.breadStatus)) {
+      throw AppError.badRequest(
+        '관리자는 주문차수에 등록할 빵 상태가 판매중, 출시예정인 경우에만 조회 가능합니다.',
+        { type, breadStatus: bread.breadStatus },
+      );
+    }
+
+    return { ...bread };
+  });
+
+  return result;
 };

--- a/apps/server/src/services/bread.service.ts
+++ b/apps/server/src/services/bread.service.ts
@@ -8,7 +8,6 @@ import { ClientType } from '@/types/client-payload';
 
 const IMAGE_TARGET_TYPE = '10'; // 빵 이미지 코드
 const CUSTOMER_AVALIABLE_BREAD_STATUS = ['10', '40', '50']; // 고객은 판매, 재료소진, 출시예정 만 조회 가능
-const USER_AVALIABLE_BREAD_STATUS = ['10', '50']; // 관리자는 판매, 출시예정만 조회한다. (주문차수 전용)
 
 /** 빵 목록 전체 조회 */
 export const getAll = async () => {
@@ -344,30 +343,4 @@ export const remove = async (noList: number[]) => {
       where: { publicId: { in: publicIdList } },
     });
   });
-};
-
-/** 빵 상세 조회 - 관리자 전용
- * 주문차수에 등록할 빵 목록을 조회한다.
- * 단, 빵 상태가 판매중(10), 출시예정(50)인 빵만 등록할 수 있다.
- */
-export const getBread = async (type: ClientType | undefined, no: number) => {
-  const result = await prisma.$transaction(async (tx) => {
-    const bread = await tx.bread.findUnique({
-      where: { no },
-    });
-
-    if (!bread) throw AppError.notFound('빵을 찾을 수 없습니다.', { breadNo: no });
-
-    // 관리자는 판매, 출시예정 만 조회 가능
-    if (type !== ClientType.USER && !USER_AVALIABLE_BREAD_STATUS.includes(bread.breadStatus)) {
-      throw AppError.badRequest(
-        '관리자는 주문차수에 등록할 빵 상태가 판매중, 출시예정인 경우에만 조회 가능합니다.',
-        { type, breadStatus: bread.breadStatus },
-      );
-    }
-
-    return { ...bread };
-  });
-
-  return result;
 };

--- a/apps/server/src/services/order-round.service.ts
+++ b/apps/server/src/services/order-round.service.ts
@@ -3,6 +3,8 @@ import { UploadedFile } from 'express-fileupload';
 import * as ImageService from './image.service';
 import { AppError } from '@/types';
 import { PrismaClient, Prisma, OrderRound, OrderRoundBread } from '@prisma/client';
+import * as BreadService from '@/services/bread.service';
+import { ClientType } from '@/types/client-payload';
 
 // 1. 주문차수 이미지 공통코드 조회 - 전역 변수로 저장
 let IMAGE_TARGET_TYPE_CODE: string | null = null;
@@ -503,4 +505,20 @@ export const getLatest = async () => {
   });
 
   return result;
+};
+
+/**
+ * 주문차수에 매핑시킬 빵이 판매중(10)인지 확인하는 함수.
+ * 빵이 1건이라도 판매중이 아니면 false를 리턴한다.
+ */
+export const findBreadStatus = async (breadNoList: number[]) => {
+  for (const breadNo of breadNoList) {
+    const findBread = await BreadService.getBread(ClientType.USER, breadNo);
+
+    if (findBread.breadStatus.includes('10') || findBread.breadStatus.includes('50')) continue;
+    else
+      return { code: 500, message: '판매중, 출시예정이 아닌 빵은 주문차수에 등록할 수 없습니다.' };
+  }
+
+  return { message: 'success' };
 };

--- a/apps/server/src/services/order-round.service.ts
+++ b/apps/server/src/services/order-round.service.ts
@@ -3,8 +3,6 @@ import { UploadedFile } from 'express-fileupload';
 import * as ImageService from './image.service';
 import { AppError } from '@/types';
 import { PrismaClient, Prisma, OrderRound, OrderRoundBread } from '@prisma/client';
-import * as BreadService from '@/services/bread.service';
-import { ClientType } from '@/types/client-payload';
 
 // 1. 주문차수 이미지 공통코드 조회 - 전역 변수로 저장
 let IMAGE_TARGET_TYPE_CODE: string | null = null;
@@ -505,20 +503,4 @@ export const getLatest = async () => {
   });
 
   return result;
-};
-
-/**
- * 주문차수에 매핑시킬 빵이 판매중(10)인지 확인하는 함수.
- * 빵이 1건이라도 판매중이 아니면 false를 리턴한다.
- */
-export const findBreadStatus = async (breadNoList: number[]) => {
-  for (const breadNo of breadNoList) {
-    const findBread = await BreadService.getBread(ClientType.USER, breadNo);
-
-    if (findBread.breadStatus.includes('10') || findBread.breadStatus.includes('50')) continue;
-    else
-      return { code: 500, message: '판매중, 출시예정이 아닌 빵은 주문차수에 등록할 수 없습니다.' };
-  }
-
-  return { message: 'success' };
 };


### PR DESCRIPTION
주문차수에 매핑될 빵을 등록할 때 
빵 상태가 판매중(10), 출시예정(50)인 빵만 등록/수정되도록 처리함.

- bread.service.ts에는 getBread 함수를 추가하였음.
   기존 빵 상세 정보 조회하는 로직은 '고객' 기준으로 되어 있어서 관리자 전용으로 빼두었음.
-  빵 상태값이 도입된다면 주문차수 startDt 에 해당될때 빵상태값을 출시예정에서 판매중으로도 변경이 돼야할 것 같음.
그래서 그냥 빼 버림.